### PR TITLE
MessageFormatter should be public

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/FormattingTuple.java
+++ b/common/src/main/java/io/netty/util/internal/logging/FormattingTuple.java
@@ -42,7 +42,7 @@ package io.netty.util.internal.logging;
 /**
  * Holds the results of formatting done by {@link MessageFormatter}.
  */
-final class FormattingTuple {
+public final class FormattingTuple {
 
     private final String message;
     private final Throwable throwable;

--- a/common/src/main/java/io/netty/util/internal/logging/MessageFormatter.java
+++ b/common/src/main/java/io/netty/util/internal/logging/MessageFormatter.java
@@ -108,7 +108,7 @@ import java.util.Set;
  * {@link #format(String, Object, Object)} and
  * {@link #arrayFormat(String, Object[])} methods for more details.
  */
-final class MessageFormatter {
+public final class MessageFormatter {
     private static final String DELIM_STR = "{}";
     private static final char ESCAPE_CHAR = '\\';
 


### PR DESCRIPTION
Allow other Logging integration to use optimised MessageFormatter implementation


Fixes #12129. 


